### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/Amazon WorkSpaces/Workspaces.pkg.recipe
+++ b/Amazon WorkSpaces/Workspaces.pkg.recipe
@@ -34,7 +34,7 @@
 				<key>pkg_payload_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/%NAME%.pkg/Payload</string>
 				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/Applications/Amazon WorkSpaces.app</string>
 			</dict>
 		</dict>
 		<dict>
@@ -45,7 +45,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/Applications/Amazon WorkSpaces.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleVersion</string>
 			</dict>

--- a/Astrill/AstrillVPN.pkg.recipe
+++ b/Astrill/AstrillVPN.pkg.recipe
@@ -45,7 +45,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/Applications/Astrill.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/DataGrip/DataGrip.pkg.recipe
+++ b/DataGrip/DataGrip.pkg.recipe
@@ -37,9 +37,9 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/DataGrip.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/DataGrip.app</string>
             </dict>
         </dict>
         <dict>
@@ -50,7 +50,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+                <string>%pkgroot%/Applications/DataGrip.app/Contents/Info.plist</string>
                 <key>plist_version_key</key>
                 <string>CFBundleShortVersionString</string>
             </dict>

--- a/Google Drive File Stream/DriveFS.pkg.recipe
+++ b/Google Drive File Stream/DriveFS.pkg.recipe
@@ -47,7 +47,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpack/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/unpack/Applications/Google Drive File Stream.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.