### PR TITLE
Basic python3 compatibility

### DIFF
--- a/DataGrip/JetbrainsURLProvider.py
+++ b/DataGrip/JetbrainsURLProvider.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import re
 import urllib
 import urllib2

--- a/DataGrip/JetbrainsURLProvider.py
+++ b/DataGrip/JetbrainsURLProvider.py
@@ -17,15 +17,13 @@
 from __future__ import absolute_import
 
 import json
-import re
-import urllib2
 
 from autopkglib import Processor, ProcessorError
 
 try:
-    from urllib import request as urllib  # For Python 3
+    from urllib.request import urlopen  # For Python 3
 except ImportError:
-    import urllib  # For Python 2
+    from urllib2 import urlopen  # For Python 2
 
 
 __all__ = ["JetbrainsURLProvider"]
@@ -118,10 +116,9 @@ class JetbrainsURLProvider(Processor):
     def xhr_release_info(self, product_code):
         """Request release information from JetBrains XHR Endpoint"""
         url = RELEASE_XHR_ENDPOINT.format(product_code, "123123123")
-        request = urllib2.Request(url)
 
         try:
-            handle = urllib2.urlopen(request)
+            handle = urlopen(url)
             response = handle.read()
             handle.close()
         except BaseException as e:

--- a/DataGrip/JetbrainsURLProvider.py
+++ b/DataGrip/JetbrainsURLProvider.py
@@ -15,12 +15,18 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-import re
-import urllib
-import urllib2
+
 import json
+import re
+import urllib2
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib import request as urllib  # For Python 3
+except ImportError:
+    import urllib  # For Python 2
+
 
 __all__ = ["JetbrainsURLProvider"]
 

--- a/DataGrip/JetbrainsURLProvider.py
+++ b/DataGrip/JetbrainsURLProvider.py
@@ -121,7 +121,7 @@ class JetbrainsURLProvider(Processor):
             handle = urlopen(url)
             response = handle.read()
             handle.close()
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError("Cannot retrieve product information from JetBrains")
 
         product_info = json.loads(response)


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later, but this should catch the low-hanging fruit right now.