### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/KeePassXC/KeePassXC.pkg.recipe
+++ b/KeePassXC/KeePassXC.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.crystalllized.pkg.KeePassXC</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>org.keepassx.keepassxc</string>
 		<key>NAME</key>
 		<string>KeePassXC</string>
 	</dict>

--- a/Keybase/Keybase.pkg.recipe
+++ b/Keybase/Keybase.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.crystalllized.pkg.Keybase</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>keybase.Electron</string>
 		<key>NAME</key>
 		<string>Keybase</string>
 	</dict>

--- a/Lua/LuaMessenger.pkg.recipe
+++ b/Lua/LuaMessenger.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.crystalllized.pkg.LuaMessenger</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.getlua.lua</string>
 		<key>NAME</key>
 		<string>Lua</string>
 	</dict>

--- a/Signal/Signal.pkg.recipe
+++ b/Signal/Signal.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.crystalllized.pkg.Signal</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>org.whispersystems.signal-desktop</string>
 		<key>NAME</key>
 		<string>Signal</string>
 	</dict>

--- a/TorBrowser/TorBrowser.pkg.recipe
+++ b/TorBrowser/TorBrowser.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.crystalllized.pkg.TorBrowser</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>org.torproject.torbrowser</string>
 		<key>NAME</key>
 		<string>TorBrowser</string>
 	</dict>

--- a/Viscosity/Viscosity.pkg.recipe
+++ b/Viscosity/Viscosity.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.crystalllized.pkg.Viscosity</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.viscosityvpn.Viscosity</string>
 		<key>NAME</key>
 		<string>Viscosity</string>
 	</dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ✅ KeePassXC/KeePassXC.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/crystalllized-recipes/KeePassXC/KeePassXC.pkg.recipe
Processing repos/crystalllized-recipes/KeePassXC/KeePassXC.pkg.recipe...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'KeePassXC-.*-x86_64\\.dmg',
           'github_repo': 'keepassxreboot/keepassxc',
           'include_prereleases': False}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Matched regex 'KeePassXC-.*-x86_64\.dmg' among asset(s): KeePassXC-2.6.4-2-arm64.dmg, KeePassXC-2.6.4-2-arm64.dmg.DIGEST, KeePassXC-2.6.4-2-arm64.dmg.sig, KeePassXC-2.6.4-arm64.dmg, KeePassXC-2.6.4-arm64.dmg.DIGEST, KeePassXC-2.6.4-arm64.dmg.sig, keepassxc-2.6.4-src.tar.xz, keepassxc-2.6.4-src.tar.xz.DIGEST, keepassxc-2.6.4-src.tar.xz.sig, KeePassXC-2.6.4-Win32-portable.zip, KeePassXC-2.6.4-Win32-portable.zip.DIGEST, KeePassXC-2.6.4-Win32-portable.zip.sig, KeePassXC-2.6.4-Win32.msi, KeePassXC-2.6.4-Win32.msi.DIGEST, KeePassXC-2.6.4-Win32.msi.sig, KeePassXC-2.6.4-Win64-portable.zip, KeePassXC-2.6.4-Win64-portable.zip.DIGEST, KeePassXC-2.6.4-Win64-portable.zip.sig, KeePassXC-2.6.4-Win64.msi, KeePassXC-2.6.4-Win64.msi.DIGEST, KeePassXC-2.6.4-Win64.msi.sig, KeePassXC-2.6.4-x86_64.AppImage, KeePassXC-2.6.4-x86_64.AppImage.DIGEST, KeePassXC-2.6.4-x86_64.AppImage.sig, KeePassXC-2.6.4-x86_64.AppImage.zsync, KeePassXC-2.6.4-x86_64.AppImage.zsync.DIGEST, KeePassXC-2.6.4-x86_64.AppImage.zsync.sig, KeePassXC-2.6.4-x86_64.dmg, KeePassXC-2.6.4-x86_64.dmg.DIGEST, KeePassXC-2.6.4-x86_64.dmg.sig
GitHubReleasesInfoProvider: Selected asset 'KeePassXC-2.6.4-x86_64.dmg' from release 'Release 2.6.4'
{'Output': {'release_notes': '### Added\r\n'
                             '\r\n'
                             '- Automatically adapt to light/dark system theme '
                             'changes (Windows/macOS only) [#6034]\r\n'
                             '\r\n'
                             '### Changed\r\n'
                             '\r\n'
                             '- Show window title as tooltip on system tray '
                             '[#5948]\r\n'
                             '- Compress Snap release as LZO for faster '
                             'initial startup [#5877]\r\n'
                             '- Password generator: Set maximum selectable '
                             'password length to 999 [#5937]\r\n'
                             '\r\n'
                             '### Fixed\r\n'
                             '\r\n'
                             '- Fix crash on app close when using SSH agent '
                             '[#5935]\r\n'
                             '- Fix KDF selection showing wrong item when '
                             'using Argon2id [#5923]\r\n'
                             '- Automatically close About dialog on database '
                             'lock if it is still open [#5947]\r\n'
                             '- Linux: Fix automatic launch at system startup '
                             'with AppImages [#5901]\r\n'
                             '- Linux: Fix click-to-move on empty area '
                             'activating when using menus [#5971]\r\n'
                             '- Linux: Try multiple times to show tray icon if '
                             'tray is not ready yet [#5948]\r\n'
                             '- macOS: Fix KeePassXC blocking clean shutdown '
                             '[#6002]',
            'url': 'https://github.com/keepassxreboot/keepassxc/releases/download/2.6.4/KeePassXC-2.6.4-x86_64.dmg',
            'version': '2.6.4'}}
URLDownloader
{'Input': {'url': 'https://github.com/keepassxreboot/keepassxc/releases/download/2.6.4/KeePassXC-2.6.4-x86_64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.KeePassXC/downloads/KeePassXC-2.6.4-x86_64.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.KeePassXC/downloads/KeePassXC-2.6.4-x86_64.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.KeePassXC/downloads/KeePassXC-2.6.4-x86_64.dmg/KeePassXC.app',
           'requirement': 'identifier "org.keepassxc.keepassxc" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'G2S7P7J672'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.KeePassXC/downloads/KeePassXC-2.6.4-x86_64.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.n0VYqj/KeePassXC.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.n0VYqj/KeePassXC.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.n0VYqj/KeePassXC.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'version': '2.6.4'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.KeePassXC/downloads/KeePassXC-2.6.4-x86_64.dmg
AppPkgCreator: Using path '/private/tmp/dmg.HrUPfB/KeePassXC.app' matched from globbed '/private/tmp/dmg.HrUPfB/*.app'.
AppPkgCreator: BundleID: org.keepassxc.keepassxc
AppPkgCreator: Package already exists at path ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.KeePassXC/KeePassXC-2.6.4.pkg.
AppPkgCreator: Existing package matches version and identifier, not building.
{'Output': {'version': '2.6.4'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.KeePassXC/receipts/KeePassXC.pkg-receipt-20210213-231014.plist

Nothing downloaded, packaged or imported.
```

## ✅ Keybase/Keybase.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/crystalllized-recipes/Keybase/Keybase.pkg.recipe
Processing repos/crystalllized-recipes/Keybase/Keybase.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Keybase.dmg',
           'url': 'https://prerelease.keybase.io/Keybase.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.Keybase/downloads/Keybase.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.Keybase/downloads/Keybase.dmg'}}
AppDmgVersioner
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.Keybase/downloads/Keybase.dmg'}}
AppDmgVersioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.Keybase/downloads/Keybase.dmg
AppDmgVersioner: BundleID: keybase.Electron
AppDmgVersioner: Version: 5.6.2-20210202191343+d72cc00cd3
{'Output': {'app_name': 'Keybase.app',
            'bundleid': 'keybase.Electron',
            'version': '5.6.2-20210202191343+d72cc00cd3'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.Keybase/downloads/Keybase.dmg/Keybase.app',
           'requirement': 'identifier "keybase.Electron" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"99229SGT5K"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.Keybase/downloads/Keybase.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.9kWWAy/Keybase.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.9kWWAy/Keybase.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.9kWWAy/Keybase.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
com.github.homebysix.VersionSplitter/VersionSplitter
{'Input': {'split_on': '-', 'version': '5.6.2-20210202191343+d72cc00cd3'}}
VersionSplitter: Split version: 5.6.2
{'Output': {'version': '5.6.2'}}
AppPkgCreator
{'Input': {'bundleid': 'keybase.Electron', 'version': '5.6.2'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.Keybase/downloads/Keybase.dmg
AppPkgCreator: Using path '/private/tmp/dmg.eS9pI1/Keybase.app' matched from globbed '/private/tmp/dmg.eS9pI1/*.app'.
AppPkgCreator: Package already exists at path ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.Keybase/Keybase-5.6.2.pkg.
AppPkgCreator: Existing package matches version and identifier, not building.
{'Output': {'version': '5.6.2'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.Keybase/receipts/Keybase.pkg-receipt-20210213-231031.plist

Nothing downloaded, packaged or imported.
```

## ❌ Lua/LuaMessenger.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/crystalllized-recipes/Lua/LuaMessenger.pkg.recipe
Processing repos/crystalllized-recipes/Lua/LuaMessenger.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Lua.dmg',
           'url': 'https://downloads.getlua.com/desktop/lua/osx64/Lua.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
Receipt written to ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.LuaMessenger/receipts/LuaMessenger.pkg-receipt-20210213-231033.plist

The following recipes failed:
    repos/crystalllized-recipes/Lua/LuaMessenger.pkg.recipe
        Error in com.github.crystalllized.pkg.LuaMessenger: Processor: URLDownloader: Error: Command '['/usr/bin/curl', '--silent', '--show-error', '--no-buffer', '--dump-header', '-', '--speed-time', '30', '--location', '--url', 'https://downloads.getlua.com/desktop/lua/osx64/Lua.dmg', '--fail', '--output', '~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.LuaMessenger/downloads/tmpuh4fkj22']' returned non-zero exit status 6.

Nothing downloaded, packaged or imported.
```

## ❌ Signal/Signal.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/crystalllized-recipes/Signal/Signal.pkg.recipe
Processing repos/crystalllized-recipes/Signal/Signal.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': '\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}',
           'result_output_var_name': 'version',
           'url': 'https://updates.signal.org/desktop/latest-mac.yml'}}
URLTextSearcher: Found matching text (version): 1.39.6
{'Output': {'version': '1.39.6'}}
URLDownloader
{'Input': {'filename': 'Signal.zip',
           'url': 'https://updates.signal.org/desktop/signal-desktop-mac-1.39.6.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.Signal/downloads/Signal.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.Signal/downloads/Signal.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.Signal/downloads/Signal.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.Signal/Signal',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename Signal.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.Signal/downloads/Signal.zip to ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.Signal/Signal
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.Signal/Signal/Signal.app',
           'requirement': 'identifier "org.whispersystems.signal-desktop" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'U68MSDN6DR'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.Signal/Signal/Signal.app: invalid resource directory (directory or signature have been modified)
CodeSignatureVerifier: In subcomponent: ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.Signal/Signal/Signal.app/Contents/Frameworks/Electron Framework.framework
Receipt written to ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.Signal/receipts/Signal.pkg-receipt-20210213-231038.plist

The following recipes failed:
    repos/crystalllized-recipes/Signal/Signal.pkg.recipe
        Error in com.github.crystalllized.pkg.Signal: Processor: CodeSignatureVerifier: Error: Code signature verification failed. Note that all verifications can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.

Nothing downloaded, packaged or imported.
```

## ✅ TorBrowser/TorBrowser.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/crystalllized-recipes/TorBrowser/TorBrowser.pkg.recipe
Processing repos/crystalllized-recipes/TorBrowser/TorBrowser.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': 'href="\\/dist\\/torbrowser\\/[\\d\\.]+\\/TorBrowser-([\\d\\.]+)-osx64_en-US\\.dmg"',
           'result_output_var_name': 'version',
           'url': 'https://www.torproject.org/download/languages/'}}
URLTextSearcher: Found matching text (version): 10.0.10
{'Output': {'version': '10.0.10'}}
URLDownloader
{'Input': {'filename': 'TorBrowser-10.0.10.dmg',
           'url': 'https://www.torproject.org/dist/torbrowser/10.0.10/TorBrowser-10.0.10-osx64_en-US.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.TorBrowser/downloads/TorBrowser-10.0.10.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.TorBrowser/downloads/TorBrowser-10.0.10.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.TorBrowser/downloads/TorBrowser-10.0.10.dmg/Tor '
                         'Browser.app',
           'requirement': 'identifier "org.torproject.torbrowser" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'MADPSAYN6T'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.TorBrowser/downloads/TorBrowser-10.0.10.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.51gJBi/Tor Browser.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.51gJBi/Tor Browser.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.51gJBi/Tor Browser.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.TorBrowser/downloads/TorBrowser-10.0.10.dmg/Tor '
                               'Browser.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.TorBrowser/downloads/TorBrowser-10.0.10.dmg
Versioner: Found version 10.0.10 in file /private/tmp/dmg.SC6eqz/Tor Browser.app/Contents/Info.plist
{'Output': {'version': '10.0.10'}}
AppPkgCreator
{'Input': {'version': '10.0.10'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.TorBrowser/downloads/TorBrowser-10.0.10.dmg
AppPkgCreator: Using path '/private/tmp/dmg.ACB8ae/Tor Browser.app' matched from globbed '/private/tmp/dmg.ACB8ae/*.app'.
AppPkgCreator: BundleID: org.torproject.torbrowser
AppPkgCreator: Copied /private/tmp/dmg.ACB8ae/Tor Browser.app to ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.TorBrowser/payload/Applications/Tor Browser.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'org.torproject.torbrowser',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.TorBrowser/Tor '
                                                                    'Browser-10.0.10.pkg',
                                                        'version': '10.0.10'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '10.0.10'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.TorBrowser/receipts/TorBrowser.pkg-receipt-20210213-231127.plist

The following packages were built:
    Identifier                 Version  Pkg Path                                                                                              
    ----------                 -------  --------                                                                                              
    org.torproject.torbrowser  10.0.10  ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.TorBrowser/Tor Browser-10.0.10.pkg  
```

## ✅ Viscosity/Viscosity.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/crystalllized-recipes/Viscosity/Viscosity.pkg.recipe
Processing repos/crystalllized-recipes/Viscosity/Viscosity.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Viscosity.dmg',
           'url': 'https://www.sparklabs.com/downloads/Viscosity.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.Viscosity/downloads/Viscosity.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.Viscosity/downloads/Viscosity.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.Viscosity/downloads/Viscosity.dmg/Viscosity.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.viscosityvpn.Viscosity" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "34XR7GXFPX")'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.Viscosity/downloads/Viscosity.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.vJ0RQw/Viscosity.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.vJ0RQw/Viscosity.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.vJ0RQw/Viscosity.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.Viscosity/downloads/Viscosity.dmg
AppPkgCreator: Using path '/private/tmp/dmg.Xf07OD/Viscosity.app' matched from globbed '/private/tmp/dmg.Xf07OD/*.app'.
AppPkgCreator: Version: 1.9.2
AppPkgCreator: BundleID: com.viscosityvpn.Viscosity
AppPkgCreator: Package already exists at path ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.Viscosity/Viscosity-1.9.2.pkg.
AppPkgCreator: Existing package matches version and identifier, not building.
{'Output': {'version': '1.9.2'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.crystalllized.pkg.Viscosity/receipts/Viscosity.pkg-receipt-20210213-231131.plist

Nothing downloaded, packaged or imported.
```

