### PR TITLE
DataGrip - pass platform key to downloader

### DIFF
--- a/DataGrip/DataGrip.download.recipe
+++ b/DataGrip/DataGrip.download.recipe
@@ -24,6 +24,8 @@
             <dict>
                 <key>product_code</key>
                 <string>DG</string>
+		<key>platform</key>
+                <string>%PLATFORM%</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Allow the "platform" key to pass to JetbrainsURLProvider so it will respect platform choice in recipe overrides. Let me know if you have any questions or concerns.

Thank you!