### PR TITLE
Support upstream arch change in parent recipe

### DIFF
--- a/KeePassXC/KeePassXC.pkg.recipe
+++ b/KeePassXC/KeePassXC.pkg.recipe
@@ -22,6 +22,11 @@
 		<dict>
 			<key>Processor</key>
 			<string>AppPkgCreator</string>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%-%ARCH%.pkg</string>
+			</dict>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
ARCH support is added to the upstream n8felton recipes, this adds the same to this pkg recipe